### PR TITLE
Add JPEG support and Mac/Linux installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,22 @@
    - Add the full path to the cloned repository folder to the list.
 
    ### For Mac/Linux:
-   - Haven't created a guide for those yet, but you can translate the code of the `email2img.bat` file or contribute to the repo.
+   - Install `uv` if you haven't already:
+     ```bash
+     curl -LsSf https://astral.sh/uv/install.sh | sh
+     ```
+   - Navigate to the cloned repository directory:
+     ```bash
+     cd /path/to/eml2img
+     ```
+   - Run the script using `uv`:
+     ```bash
+     uv run EmailToImg/main.py your_file.eml -o output_folder/
+     ```
+   - For batch processing a folder:
+     ```bash
+     uv run EmailToImg/main.py --parse-folder /path/to/eml/folder -o output_folder/
+     ```
 
 ## Usage
 


### PR DESCRIPTION
This PR adds support for JPEG images in addition to PNG images and includes Mac/Linux installation instructions using uv.

## Changes:
- Extended Content-Type detection to handle both PNG and JPEG images
- Fixed multi-line header parsing for EML files with tab-indented names  
- Corrected boundary detection for multipart/mixed content
- Fixed base64 data capture logic to properly extract image content
- Added Mac/Linux installation instructions using uv
- Added extract_image_name_from_line() helper function

## Testing:
- Tested with sample EML file containing 6 JPEG images
- All images extracted successfully with proper file sizes
- Maintains backward compatibility with existing PNG functionality